### PR TITLE
Rewrite landing page with vuetify

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -17,25 +17,88 @@ limitations under the License.
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="UTF-8">
-    <title>CodeU 2019 Starter Project</title>
-    <link rel="stylesheet" href="/css/main.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.min.css" rel="stylesheet">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <script src="/js/navigation-loader.js"></script>
 </head>
 <body onload="addLoginOrLogoutLinkToNavigation();">
-<nav>
-    <ul id="navigation">
-        <li><a href="/">Home</a></li>
-        <li><a href="/aboutus.html">About Our Team</a></li>
-        <li><a href="/feed.html">Public Feeds</a></li>
-    </ul>
-</nav>
-<h1>CodeU Starter Project</h1>
-<p>This is the CodeU starter project. Click the links above to login and visit your page.
-    You can post messages on your page, and you can visit other user pages if you have
-    their URL.</p>
-<p>This is your code now! Feel free to make changes, and don't be afraid to get creative!
-    You could start by modifying this page to tell the world more about your team.</p>
+<div id="app">
+    <v-app>
+        <v-content>
+            <v-toolbar dark color="blue-grey lighten-5" class="elevation-0">
+                <v-toolbar-side-icon @click="toggleDrawer" light
+                ></v-toolbar-side-icon>
+
+                <v-toolbar-title class="black--text">CodeU 2019 Starter Project</v-toolbar-title>
+
+                <v-spacer></v-spacer>
+
+                <v-btn icon>
+                    <v-icon>search</v-icon>
+                </v-btn>
+
+                <v-btn icon>
+                    <v-icon>apps</v-icon>
+                </v-btn>
+
+            </v-toolbar>
+                <v-navigation-drawer permanent hide-overlay v-show="drawer.open">
+                    <v-toolbar flat>
+                        <v-list>
+                            <v-list-tile>
+                                <v-list-tile-title class="title">
+                                    Application
+                                </v-list-tile-title>
+                            </v-list-tile>
+                        </v-list>
+                    </v-toolbar>
+
+                    <v-divider></v-divider>
+
+                    <v-list id="navigation" dense class="pt-0">
+                        <v-list-tile
+                                v-for="item in items"
+                                :key="item.title"
+                                :href="item.url"
+                        >
+                            <v-list-tile-action>
+                                <v-icon>{{ item.icon }}</v-icon>
+                            </v-list-tile-action>
+
+                            <v-list-tile-content>
+                                <v-list-tile-title>{{ item.title }}</v-list-tile-title>
+                            </v-list-tile-content>
+                        </v-list-tile>
+                    </v-list>
+                </v-navigation-drawer>
+        </v-content>
+    </v-app>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.js"></script>
+<script>
+    new Vue({
+      el: '#app',
+      data: () => ({
+        items: [
+          { title: 'Home', icon: 'dashboard', url: '/' },
+          { title: 'About Our Team', icon: 'question_answer', url: '/aboutus.html' },
+          { title: 'Public Feed', icon: 'question_answer', url: '/feed.html' }
+        ],
+        drawer: {
+            open : false,
+        }
+      }),
+
+      methods: {
+        toggleDrawer(){
+            this.drawer.open = !this.drawer.open
+        }
+      }
+    })
+ </script>
 </body>
 </html>
 

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -43,35 +43,35 @@ limitations under the License.
                 </v-btn>
 
             </v-toolbar>
-                <v-navigation-drawer permanent hide-overlay v-show="drawer.open">
-                    <v-toolbar flat>
-                        <v-list>
-                            <v-list-tile>
-                                <v-list-tile-title class="title">
-                                    Application
-                                </v-list-tile-title>
-                            </v-list-tile>
-                        </v-list>
-                    </v-toolbar>
-
-                    <v-divider></v-divider>
-
-                    <v-list id="navigation" dense class="pt-0">
-                        <v-list-tile
-                                v-for="item in items"
-                                :key="item.title"
-                                :href="item.url"
-                        >
-                            <v-list-tile-action>
-                                <v-icon>{{ item.icon }}</v-icon>
-                            </v-list-tile-action>
-
-                            <v-list-tile-content>
-                                <v-list-tile-title>{{ item.title }}</v-list-tile-title>
-                            </v-list-tile-content>
+            <v-navigation-drawer permanent hide-overlay v-show="drawer.open">
+                <v-toolbar flat>
+                    <v-list>
+                        <v-list-tile>
+                            <v-list-tile-title class="title">
+                                Application
+                            </v-list-tile-title>
                         </v-list-tile>
                     </v-list>
-                </v-navigation-drawer>
+                </v-toolbar>
+
+                <v-divider></v-divider>
+
+                <v-list id="navigation" dense class="pt-0">
+                    <v-list-tile
+                            v-for="item in items"
+                            :key="item.title"
+                            :href="item.url"
+                    >
+                        <v-list-tile-action>
+                            <v-icon>{{ item.icon }}</v-icon>
+                        </v-list-tile-action>
+
+                        <v-list-tile-content>
+                            <v-list-tile-title>{{ item.title }}</v-list-tile-title>
+                        </v-list-tile-content>
+                    </v-list-tile>
+                </v-list>
+            </v-navigation-drawer>
         </v-content>
     </v-app>
 </div>
@@ -98,7 +98,7 @@ limitations under the License.
         }
       }
     })
- </script>
+</script>
 </body>
 </html>
 

--- a/src/main/webapp/js/navigation-loader.js
+++ b/src/main/webapp/js/navigation-loader.js
@@ -48,8 +48,9 @@ function addLoginOrLogoutLinkToNavigation() {
  * @param {Element} childElement
  * @return {Element} li element
  */
-function createListItem(childElement) {
-  const listItemElement = document.createElement('li');
+function createListItem(childElement) {;
+  const listItemElement = document.createElement('div');
+  listItemElement.setAttribute("role", "listitem");
   listItemElement.appendChild(childElement);
   return listItemElement;
 }
@@ -62,7 +63,25 @@ function createListItem(childElement) {
  */
 function createLink(url, text) {
   const linkElement = document.createElement('a');
-  linkElement.appendChild(document.createTextNode(text));
   linkElement.href = url;
+  linkElement.setAttribute("class", "v-list__tile v-list__tile--link theme--light");
+  const listAction = document.createElement('div');
+  listAction.setAttribute("class", "v-list__tile__action");
+  const listContent = document.createElement('div');
+  listContent.setAttribute("class", "v-list__tile__content");
+
+  const icon = document.createElement('i');
+  icon.setAttribute("class", "v-icon material-icons theme--light");
+  icon.setAttribute("aria-hidden", "true");
+  icon.innerHTML = 'person';
+  listAction.appendChild(icon);
+
+  const textContent = document.createElement('div');
+  textContent.setAttribute("class", "v-list__tile__title");
+  textContent.innerHTML = text;
+  listContent.appendChild(textContent);
+
+  linkElement.appendChild(listAction);
+  linkElement.appendChild(listContent);
   return linkElement;
 }


### PR DESCRIPTION
Rewrite landing page with Vuetify and modify login/logout functions to match style.
To test:
1) run devserver and go to localhost:8080/
2) clicking on the icon in the toolbar will show a navigation drawer like below.
3) the page links works as the original landing page and log in, logout as well.
<img width="531" alt="螢幕快照 2019-06-28 下午6 32 45" src="https://user-images.githubusercontent.com/22865207/60336516-22a68b80-99d3-11e9-87c6-30df9273cbd2.png">
