### PR TITLE
Add translate button for public feed and fix some bugs

### DIFF
--- a/src/main/java/com/google/codeu/servlets/MessageFeedServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageFeedServlet.java
@@ -34,9 +34,10 @@ public class MessageFeedServlet extends HttpServlet {
             throws IOException {
 
         response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
         List<Message> messages = datastore.getAllMessages();
         Gson gson = new Gson();
         String json = gson.toJson(messages);
-        response.getOutputStream().println(json);
+        response.getWriter().println(json);
     }
 }

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -62,6 +62,7 @@ public class MessageServlet extends HttpServlet {
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
         response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
 
         String user = request.getParameter("user");
 
@@ -92,11 +93,10 @@ public class MessageServlet extends HttpServlet {
 
         String user = userService.getCurrentUser().getEmail();
 
-        String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
+        String text = request.getParameter("text");
         Whitelist whitelist = Whitelist.basicWithImages();
         whitelist.addTags("h1", "h2", "h3", "h4", "h5", "h6");
         String userText = Jsoup.clean(text, whitelist);
-        
 
         //add photo into message
         String regex = "(https?://\\S+\\.(png|jpg))";

--- a/src/main/webapp/feed.html
+++ b/src/main/webapp/feed.html
@@ -27,22 +27,52 @@
   }
 
    function buildMessageDiv(message){
-   const usernameDiv = document.createElement('div');
-   usernameDiv.classList.add("left-align");
-   usernameDiv.appendChild(document.createTextNode(message.user));
+       const usernameDiv = document.createElement('div');
+       usernameDiv.classList.add("left-align");
+       usernameDiv.appendChild(document.createTextNode(message.user));
 
-   const timeDiv = document.createElement('div');
-   timeDiv.classList.add('right-align');
-   timeDiv.appendChild(document.createTextNode(new Date(message.timestamp)));
+       const timeDiv = document.createElement('div');
+       timeDiv.classList.add('right-align');
+       timeDiv.appendChild(document.createTextNode(new Date(message.timestamp)));
 
-   const headerDiv = document.createElement('div');
-   headerDiv.classList.add('message-header');
-   headerDiv.appendChild(usernameDiv);
-   headerDiv.appendChild(timeDiv);
+       const headerDiv = document.createElement('div');
+       headerDiv.classList.add('message-header');
+       headerDiv.appendChild(usernameDiv);
+       headerDiv.appendChild(timeDiv);
 
-   const bodyDiv = document.createElement('div');
-   bodyDiv.classList.add('message-body');
-   bodyDiv.appendChild(document.createTextNode(message.text));
+       const bodyDiv = document.createElement('div');
+       bodyDiv.classList.add('message-body');
+       const messageBody = document.createElement('div');
+       messageBody.innerHTML = message.text;
+       bodyDiv.appendChild(messageBody);
+
+       //create translate button
+       bodyDiv.classList.add('translate-button');
+       const translateButton = document.createElement("input");
+       translateButton.type = "button";
+       translateButton.value = "Translate";
+       console.log(message.text);
+       translateButton.addEventListener('click', function(){
+           if (this.value === "Translate"){
+                const language = window.navigator.language;
+                const params = new URLSearchParams();
+                params.append('text', message.text);
+                params.append('languageCode', language);
+
+                fetch('/translate', {
+                  method: 'POST',
+                  body: params
+                }).then(response => response.text())
+                .then((translatedMessage) => {
+                  messageBody.innerHTML = translatedMessage;
+                  this.value = 'See Original';
+                });
+           } else {
+                messageBody.innerHTML = message.text;
+                this.value = 'Translate';
+           }
+       });
+   bodyDiv.appendChild(translateButton);
 
    const messageDiv = document.createElement('div');
    messageDiv.classList.add("message-div");

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -233,7 +233,7 @@ height:700px;
             </div>
             <v-container grid-list-md text-xs-center class="Aboutus_container">
                 <v-layout align-center justify-center row fill-height>
-                    <v-flex v-for="i in members" :key="`3${i}`" xs3>
+                    <v-flex v-for="i in members" :key="`3${i.name_en}`" xs3>
 
                         <v-hover>
                             <v-card


### PR DESCRIPTION
- Add translate button for each message in public feed that detects the browser language and translates the message into the browser language. Click the button again and it will show the original message. 

-  Change message feed servlet and message servlet response type to UTF8 to support non-ISO 8859-1 characters (e.g. japanese characters).

-  Remove whitelist.none() to allow html tags and change createTextNode() to createElement() for message body to fix p-tag showing bug.

-  Fix index.html page duplicate key bug for about us cards. 

To test:
1) Run devserver and go to localhost:8080
2) Generate some messages
3) Go to public feed page and try the translate/see original button.