### PR TITLE
remove map, community, status, translate pages

### DIFF
--- a/src/main/webapp/feed.html
+++ b/src/main/webapp/feed.html
@@ -123,6 +123,6 @@
 </div>
 <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.js"></script>
-<script type="text/javascript" src="/js/navigationbar-loader.js"></script>>
+<script type="text/javascript" src="/js/navigationbar-loader.js"></script>
 </body>
 </html>

--- a/src/main/webapp/feed.html
+++ b/src/main/webapp/feed.html
@@ -4,6 +4,7 @@
     <title>Message Feed</title>
     <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.min.css" rel="stylesheet">
+    <script src="/js/navigation-loader.js"></script>
     <meta charset="UTF-8">
 <!--    <link rel="stylesheet" href="/css/main.css">-->
 <!--    <link rel="stylesheet" href="/css/user-page.css">-->

--- a/src/main/webapp/feed.html
+++ b/src/main/webapp/feed.html
@@ -2,8 +2,11 @@
 <html>
 <head>
     <title>Message Feed</title>
-    <link rel="stylesheet" href="/css/main.css">
-    <link rel="stylesheet" href="/css/user-page.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.min.css" rel="stylesheet">
+    <meta charset="UTF-8">
+<!--    <link rel="stylesheet" href="/css/main.css">-->
+<!--    <link rel="stylesheet" href="/css/user-page.css">-->
 
     <script>
     // Fetch messages and add them to the page.
@@ -61,10 +64,65 @@
     </script>
 </head>
 <body onload="buildUI()">
-<div id="content">
-    <h1>Message Feed</h1>
-    <hr/>
-    <div id="message-container">Loading...</div>
+<div id="app">
+    <v-app>
+        <v-content>
+            <v-toolbar light class="elevation-0">
+                <v-toolbar-side-icon @click="toggleDrawer" light
+                ></v-toolbar-side-icon>
+
+                <v-toolbar-title>Message Feed</v-toolbar-title>
+
+                <v-spacer></v-spacer>
+
+                <v-btn icon>
+                    <v-icon>search</v-icon>
+                </v-btn>
+
+                <v-btn icon>
+                    <v-icon>apps</v-icon>
+                </v-btn>
+
+            </v-toolbar>
+            <v-navigation-drawer permanent hide-overlay v-show="drawer.open">
+                <v-toolbar flat>
+                    <v-list>
+                        <v-list-tile>
+                            <v-list-tile-title class="title">
+                                Application
+                            </v-list-tile-title>
+                        </v-list-tile>
+                    </v-list>
+                </v-toolbar>
+
+                <v-divider></v-divider>
+
+                <v-list id="navigation" dense class="pt-0">
+                    <v-list-tile
+                            v-for="item in items"
+                            :key="item.title"
+                            :href="item.url"
+                    >
+                        <v-list-tile-action>
+                            <v-icon>{{ item.icon }}</v-icon>
+                        </v-list-tile-action>
+
+                        <v-list-tile-content>
+                            <v-list-tile-title>{{ item.title }}</v-list-tile-title>
+                        </v-list-tile-content>
+                    </v-list-tile>
+                </v-list>
+            </v-navigation-drawer>
+
+            <div id="content">
+
+                <div id="message-container">Loading...</div>
+            </div>
+        </v-content>
+    </v-app>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.js"></script>
+<script type="text/javascript" src="/js/navigationbar-loader.js"></script>>
 </body>
 </html>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -316,11 +316,7 @@ height:700px;
           pages: [
           { title: 'Home', icon: 'dashboard', url: '/' },
           { title: 'My-info', icon: 'edit', url: '/user-info.html' },
-          { title: 'Public Feed', icon: 'question_answer', url: '/feed.html' },
-          { title: 'Map', icon: 'place', url: '/map.html' },
-          { title: 'Community', icon: 'mode_comment', url: '/community.html' },
-          { title: 'Status', icon: 'pie_chart', url: '/stats.html' },
-          { title: 'Translate', icon: 'translate', url: '/translate.html' }
+          { title: 'Public Feed', icon: 'question_answer', url: '/feed.html' }
         ],
         members: [
           { photo: "https://avatars0.githubusercontent.com/u/37070724?s=400&v=4", name_en: 'Alison', facebook: "https://www.facebook.com/profile.php?id=100021710384904",name_ch:'XuanTing Zhang' },

--- a/src/main/webapp/js/navigationbar-loader.js
+++ b/src/main/webapp/js/navigationbar-loader.js
@@ -1,0 +1,18 @@
+//for the tool bar
+    new Vue({ el: '#app',
+     data: () => ({
+        items: [
+          { title: 'Home', icon: 'dashboard', url: '/' },
+          { title: 'My-info', icon: 'edit', url: '/user-info.html' },
+          { title: 'Public Feed', icon: 'question_answer', url: '/feed.html' }
+        ],
+        drawer: {
+            open : false,
+        }
+      }),
+      methods: {
+        toggleDrawer(){
+            this.drawer.open = !this.drawer.open
+        }
+      }
+    })

--- a/src/main/webapp/skill-search.html
+++ b/src/main/webapp/skill-search.html
@@ -265,11 +265,7 @@
         items: [
             { title: 'Home', icon: 'dashboard', url: '/' },
             { title: 'My-info', icon: 'edit', url: '/user-info.html' },
-            { title: 'Public Feed', icon: 'question_answer', url: '/feed.html' },
-            { title: 'Map', icon: 'place', url: '/map.html' },
-            { title: 'Community', icon: 'mode_comment', url: '/community.html' },
-            { title: 'Status', icon: 'pie_chart', url: '/stats.html' },
-            { title: 'Translate', icon: 'translate', url: '/translate.html' }
+            { title: 'Public Feed', icon: 'question_answer', url: '/feed.html' }
         ],
         drawer: {
             open : false,


### PR DESCRIPTION
I have removed the map, community, status, translate pages on the navigation bar.
After @Junochiu styling, other pages may be moved to the toolbar.
Feel free to command. 
![image](https://user-images.githubusercontent.com/40991040/60993618-6315ea00-a381-11e9-8dab-5c42bfc86136.png)
